### PR TITLE
Address some of Mishi's comments on the CoC

### DIFF
--- a/conduct/code-of-conduct.md
+++ b/conduct/code-of-conduct.md
@@ -6,7 +6,7 @@ This is a template code of conduct that event organizers can use for conferences
 
 A **Code of Conduct** is useful to define accepted and acceptable behaviors and to promote high standards of professional practice. It also provides a benchmark for self evaluation and acts as a vehicle for better identity of the community and organization. If you have general questions about codes of conduct, a good place to start is this [code of conduct FAQ](https://www.ashedryden.com/blog/codes-of-conduct-101-faq#cocfaq).
 
-This code (CoC) applies to any participant at `<EVENT>`, including participants in meetings, teleconferences, and mailing lists, as well as in-person events. Note that this code augments rather than replaces legal rights and obligations pertaining to any particular situation.
+This code (CoC) applies to any participant at `<EVENT>`, including participants in meetings and teleconferences, vendors, staff, and volunteers. Note that this code augments rather than replaces legal rights and obligations pertaining to any particular situation.
 
 ## Expected Behavior
 
@@ -38,13 +38,6 @@ harassment purposes.
 except as necessary to protect vulnerable people from intentional abuse.
 * Publication of non-harassing private communication.  
 
-`<EVENT>` prioritizes marginalized people's safety over privileged people's comfort. We will not act on complaints regarding:
-
-* 'Reverse' -isms, including 'reverse racism,' 'reverse sexism,' and 'cisphobia'.
-* Reasonable communication of boundaries, such as "leave me alone," "go away," or "I'm not discussing this with you."
-* Communicating in a 'tone' you don't find congenial.
-* Criticizing racist, sexist, cissexist, or otherwise oppressive behavior or assumptions.
-
 ### Harassment in online channels
 
 Participants at `<EVENT>` may also participate in online chats, discussion forums, and mailing lists (including platforms such as Slack and Twitter). Please use these guidelines where engaging with particpants:
@@ -60,7 +53,7 @@ While this code of conduct applies to spaces associated with `<EVENT>`, if you a
 
 In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we believe to have been made in bad faith. Reports intended to silence legitimate criticism may be deleted without response.
 
-We will respect confidentiality requests for the purpose of protecting victims of abuse. At our discretion, we may publicly name a person about whom we've received harassment complaints, or privately warn third parties about them if we believe that doing so will increase the safety of `<EVENT>` participants or the general public. We will not name harassment victims without their affirmative consent.
+We will respect confidentiality requests for the purpose of protecting victims of abuse. We will not name harassment victims without their affirmative consent.
 
 Conference staff will also provide support to victims, including, but not limited to:
 


### PR DESCRIPTION
At Mishi's suggestion, this PR:
* adds clarity about who the CoC applies to
* removes the section beginning "<EVENT> prioritizes marginalized people's safety over privileged people's comfort...". Mishi's experience is that this language causes big problems for events that use it and that it is better to leave it out (which is not to say that it won't be true -- i.e. just because the CoC _doesn't_ say that organizers _won't_ respond to complaints of reverse racism doesn't mean they do have to respond to them). I am torn because while I see her point I also feel like this language sends a valuable signal to people in marginalized groups who are most vulnerable to harassment. Others' thoughts very welcome.
* removes "At our discretion, we may publicly name a person..."

Still to do:

* add additional language about values in the first few paragraphs
* clarify the parts around online communication (which channels, when, etc.)