### PR TITLE
Update CoC documentation

### DIFF
--- a/conduct/README.md
+++ b/conduct/README.md
@@ -1,13 +1,19 @@
 # README
 
-This folder contains a draft code of conduct (CoC) that event organizers in the R
+This folder contains a code of conduct (CoC) that event organizers in the R
 community can use. This CoC was adapted from the
 [R-Ladies Code of Conduct](https://rladies.org/code-of-conduct/). 
 If you plan to use this CoC for your event, fill in your contact details and any
 other event-specific information. 
 
-The document covers many details that the working group considers important in a
-code of conduct, but not every detail may be right for every event. So
-organizers should still take care to ensure that the CoC reflects the values and
-behaviors they are prepared to enforce.
+This CoC is a collaborative effort of the R Consortium Diversity and Inclusion
+Working group and has undergone review from working group members as well as
+legal counsel. The document covers many details that the working group considers
+important in a code of conduct, but not every detail may be right for every
+event. Organizers should take care to ensure that the CoC reflects the values
+and behaviors they are prepared to enforce, and should consult with their own
+legal counsel over any questions or concerns.
+
+For more guidance on codes of conduct and enforcement, see the
+[resources](resources.md) we've gathered.
 

--- a/conduct/code-of-conduct.md
+++ b/conduct/code-of-conduct.md
@@ -1,3 +1,5 @@
+Version: 1.0
+
 This is a template code of conduct that event organizers can use for conferences, meetups, and other events. You'll need to replace the `<EVENT>`, `<RESPONSE TEAM>`, and `<EMAIL ADDRESS>` placeholders with information specific to your event.
 
 # Code of Conduct


### PR DESCRIPTION
Adds a little context to the README (the "resources" link will work once #18 is merged) and gives a version number to the CoC.