### PR TITLE
fixing typos on front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # R Community Diversity and Inclusion Working Group
 
 ## Goal
-The goal of the R Community Diversity and Inclusion Working Group (RCDI-WG) is to broadly consider how the R Consortium can best encourage and support diverse and inclusion. The short-term priority is to define and publicise on best practices for R community events, and ensure that events funded by the R consortium adhere to those guidelines. In the long term, the RCDI-WG will think about how diversity and inclusion can we woven throughout all R consortium activities. 
+The goal of the R Community Diversity and Inclusion Working Group (RCDI-WG) is to broadly consider how the R Consortium can best encourage and support diverse and inclusion. The short-term priority is to define and publicise on best practices for R community events, and ensure that events funded by the R consortium adhere to those guidelines. In the long term, the RCDI-WG will think about how diversity and inclusion can be woven throughout all R Consortium activities. 
 
 ## Membership
 


### PR DESCRIPTION
I think we want to use uppercase "C" for consortium in this case because we are talking about the R Consortium